### PR TITLE
fix: Add missing AVERAGE_LINE_LENGTH constant in DiffChunkerService

### DIFF
--- a/src/server/services/diff-chunker-service.ts
+++ b/src/server/services/diff-chunker-service.ts
@@ -20,6 +20,7 @@ interface FileBlock {
 export class DiffChunkerService {
   private config: ChunkingConfig;
   private readonly MIN_CHUNK_SIZE = 100; // Minimum viable chunk size
+  private readonly AVERAGE_LINE_LENGTH = 50; // Average characters per line in diffs
 
   constructor(config?: Partial<ChunkingConfig>) {
     const globalConfig = getConfigManager().getChunkingConfig();
@@ -162,7 +163,7 @@ export class DiffChunkerService {
       // Add overlap for next chunk
       if (lineIndex < lines.length) {
         const overlapLines = Math.min(
-          Math.floor(this.config.overlapSize / AVERAGE_LINE_LENGTH),
+          Math.floor(this.config.overlapSize / this.AVERAGE_LINE_LENGTH),
           lineIndex - startIndex
         );
         lineIndex = Math.max(startIndex + 1, lineIndex - overlapLines);


### PR DESCRIPTION
- Define AVERAGE_LINE_LENGTH as a private readonly constant (50 chars/line)
- Fix TypeScript compilation error in size-based chunking overlap calculation
- Resolves build failure when running npm start

🤖 Generated with [Claude Code](https://claude.ai/code)